### PR TITLE
Make MarkerLayer compatible with React v16

### DIFF
--- a/lib/MarkerLayer.js
+++ b/lib/MarkerLayer.js
@@ -12,43 +12,39 @@ var _reactDom = require('react-dom');
 
 var _reactDom2 = _interopRequireDefault(_reactDom);
 
-var _lodash = require('lodash.map');
+var _propTypes = require('prop-types');
 
-var _lodash2 = _interopRequireDefault(_lodash);
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
-var _lodash3 = require('lodash.foreach');
+var _map = require('lodash/map');
 
-var _lodash4 = _interopRequireDefault(_lodash3);
+var _map2 = _interopRequireDefault(_map);
 
-var _lodash5 = require('lodash.pluck');
+var _forEach = require('lodash/forEach');
 
-var _lodash6 = _interopRequireDefault(_lodash5);
+var _forEach2 = _interopRequireDefault(_forEach);
 
-var _lodash7 = require('lodash.min');
+var _min = require('lodash/min');
 
-var _lodash8 = _interopRequireDefault(_lodash7);
+var _min2 = _interopRequireDefault(_min);
 
-var _lodash9 = require('lodash.max');
+var _max = require('lodash/max');
 
-var _lodash10 = _interopRequireDefault(_lodash9);
+var _max2 = _interopRequireDefault(_max);
 
-var _lodash11 = require('lodash.isnumber');
+var _isNumber = require('lodash/isNumber');
 
-var _lodash12 = _interopRequireDefault(_lodash11);
+var _isNumber2 = _interopRequireDefault(_isNumber);
 
-var _lodash13 = require('lodash.filter');
+var _filter = require('lodash/filter');
 
-var _lodash14 = _interopRequireDefault(_lodash13);
+var _filter2 = _interopRequireDefault(_filter);
 
 var _leaflet = require('leaflet');
 
 var _leaflet2 = _interopRequireDefault(_leaflet);
 
 var _reactLeaflet = require('react-leaflet');
-
-var _function = require('react-pure-render/function');
-
-var _function2 = _interopRequireDefault(_function);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -59,7 +55,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 function isInvalid(num) {
-  return !(0, _lodash12.default)(num) && !num;
+  return !(0, _isNumber2.default)(num) && !num;
 }
 
 function isValid(num) {
@@ -73,25 +69,30 @@ function shouldIgnoreLocation(loc) {
 var MarkerLayer = function (_MapLayer) {
   _inherits(MarkerLayer, _MapLayer);
 
-  function MarkerLayer() {
-    var _temp, _this, _ret;
-
+  function MarkerLayer(props, context) {
     _classCallCheck(this, MarkerLayer);
 
-    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-      args[_key] = arguments[_key];
-    }
+    var _this = _possibleConstructorReturn(this, _MapLayer.call(this, props, context));
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, _MapLayer.call.apply(_MapLayer, [this].concat(args))), _this), _this.shouldComponentUpdate = _function2.default, _temp), _possibleConstructorReturn(_this, _ret);
+    _this.map = null;
+    _this.markers = {};
+    _this.container = null;
+
+    _this.map = undefined !== props.map ? props.map : context.map;
+    return _this;
   }
+
+  MarkerLayer.prototype.createLeafletElement = function createLeafletElement(props) {
+    return null;
+  };
 
   MarkerLayer.prototype.componentWillReceiveProps = function componentWillReceiveProps() {
     // no-op to override MapLayer behavior
   };
 
   MarkerLayer.prototype.componentDidMount = function componentDidMount() {
-    this.leafletElement = _reactDom2.default.findDOMNode(this.refs.container);
-    this.props.map.getPanes().overlayPane.appendChild(this.leafletElement);
+    this.leafletElement = _reactDom2.default.findDOMNode(this.container);
+    this.map.getPanes().overlayPane.appendChild(this.leafletElement);
     if (this.props.fitBoundsOnLoad) {
       this.fitBounds();
     }
@@ -100,38 +101,38 @@ var MarkerLayer = function (_MapLayer) {
   };
 
   MarkerLayer.prototype.componentWillUnmount = function componentWillUnmount() {
-    this.props.map.getPanes().overlayPane.removeChild(this.leafletElement);
+    this.map.getPanes().overlayPane.removeChild(this.leafletElement);
   };
 
   MarkerLayer.prototype.fitBounds = function fitBounds() {
     var markers = this.props.markers;
-    var lngs = (0, _lodash14.default)((0, _lodash2.default)(markers, this.props.longitudeExtractor), isValid);
-    var lats = (0, _lodash14.default)((0, _lodash2.default)(markers, this.props.latitudeExtractor), isValid);
-    var ne = { lng: (0, _lodash10.default)(lngs), lat: (0, _lodash10.default)(lats) };
-    var sw = { lng: (0, _lodash8.default)(lngs), lat: (0, _lodash8.default)(lats) };
+    var lngs = (0, _filter2.default)((0, _map2.default)(markers, this.props.longitudeExtractor), isValid);
+    var lats = (0, _filter2.default)((0, _map2.default)(markers, this.props.latitudeExtractor), isValid);
+    var ne = { lng: (0, _max2.default)(lngs), lat: (0, _max2.default)(lats) };
+    var sw = { lng: (0, _min2.default)(lngs), lat: (0, _min2.default)(lats) };
 
     if (shouldIgnoreLocation(ne) || shouldIgnoreLocation(sw)) {
       return;
     }
 
-    this.props.map.fitBounds(_leaflet2.default.latLngBounds(_leaflet2.default.latLng(sw), _leaflet2.default.latLng(ne)));
+    this.map.fitBounds(_leaflet2.default.latLngBounds(_leaflet2.default.latLng(sw), _leaflet2.default.latLng(ne)));
   };
 
-  MarkerLayer.prototype.componentDidUpdate = function componentDidUpdate() {
-    this.props.map.invalidateSize();
-    if (this.props.fitBoundsOnUpdate) {
+  MarkerLayer.prototype.markersOrPositionExtractorsChanged = function markersOrPositionExtractorsChanged(props) {
+    return this.props.markers !== props.markers || this.props.longitudeExtractor !== props.longitudeExtractor || this.props.latitudeExtractor !== props.latitudeExtractor;
+  };
+
+  MarkerLayer.prototype.componentDidUpdate = function componentDidUpdate(prevProps) {
+    this.map.invalidateSize();
+    if (this.props.fitBoundsOnUpdate && this.markersOrPositionExtractorsChanged(prevProps)) {
       this.fitBounds();
     }
     this.updatePosition();
   };
 
   MarkerLayer.prototype.attachEvents = function attachEvents() {
-    var _this2 = this;
-
-    var map = this.props.map;
-    map.on('viewreset', function () {
-      return _this2.updatePosition();
-    });
+    this.map.on('zoomend', this.updatePosition.bind(this));
+    this.map.on('viewreset', this.updatePosition.bind(this));
   };
 
   MarkerLayer.prototype.getLocationForMarker = function getLocationForMarker(marker) {
@@ -142,27 +143,37 @@ var MarkerLayer = function (_MapLayer) {
   };
 
   MarkerLayer.prototype.updatePosition = function updatePosition() {
-    var _this3 = this;
+    var _this2 = this;
 
-    (0, _lodash4.default)(this.props.markers, function (marker, i) {
-      var markerElement = _reactDom2.default.findDOMNode(_this3.refs[_this3.getMarkerRefName(i)]);
+    (0, _forEach2.default)(this.props.markers, function (marker, i) {
+      var markerComponent = _this2.markers[_this2.getMarkerRefName(i)];
 
-      var location = _this3.getLocationForMarker(marker);
+      if (!markerComponent || !markerComponent.ref) {
+        throw new Error('Missing reference: Please add a reference to your Marker element, by adding \'ref={(c) => this.ref = c}\' to your marker\'s root tag');
+      }
 
-      if (shouldIgnoreLocation(location)) {
+      var markerElement = _reactDom2.default.findDOMNode(markerComponent.ref);
+
+      var location = _this2.getLocationForMarker(marker);
+
+      if (!markerElement || shouldIgnoreLocation(location)) {
         return;
       }
 
-      var point = _this3.props.map.latLngToLayerPoint(_leaflet2.default.latLng(location));
+      var point = _this2.map.latLngToLayerPoint(_leaflet2.default.latLng(location));
 
       _leaflet2.default.DomUtil.setPosition(markerElement, point);
     });
   };
 
   MarkerLayer.prototype.render = function render() {
+    var _this3 = this;
+
     return _react2.default.createElement(
       'div',
-      { ref: 'container',
+      { ref: function ref(c) {
+          return _this3.container = c;
+        },
         className: 'leaflet-objects-pane\n           leaflet-marker-pane\n           leaflet-zoom-hide\n           react-leaflet-marker-layer' },
       this.renderMarkers()
     );
@@ -173,7 +184,7 @@ var MarkerLayer = function (_MapLayer) {
 
     var style = { position: 'absolute' };
     var MarkerComponent = this.props.markerComponent;
-    return (0, _lodash2.default)(this.props.markers, function (marker, index) {
+    return (0, _map2.default)(this.props.markers, function (marker, index) {
       if (shouldIgnoreLocation(_this4.getLocationForMarker(marker))) {
         return;
       }
@@ -181,8 +192,10 @@ var MarkerLayer = function (_MapLayer) {
       return _react2.default.createElement(MarkerComponent, _extends({}, _this4.props.propsForMarkers, {
         key: index,
         style: style,
-        map: _this4.props.map,
-        ref: _this4.getMarkerRefName(index),
+        map: _this4.map,
+        ref: function ref(c) {
+          return _this4.markers[_this4.getMarkerRefName(index)] = c;
+        },
         marker: marker }));
     });
   };
@@ -195,12 +208,12 @@ var MarkerLayer = function (_MapLayer) {
 }(_reactLeaflet.MapLayer);
 
 MarkerLayer.propTypes = {
-  markers: _react2.default.PropTypes.array,
-  longitudeExtractor: _react2.default.PropTypes.func.isRequired,
-  latitudeExtractor: _react2.default.PropTypes.func.isRequired,
-  markerComponent: _react2.default.PropTypes.func.isRequired,
-  propsForMarkers: _react2.default.PropTypes.object,
-  fitBoundsOnLoad: _react2.default.PropTypes.bool,
-  fitBoundsOnUpdate: _react2.default.PropTypes.bool
+  markers: _propTypes2.default.array,
+  longitudeExtractor: _propTypes2.default.func.isRequired,
+  latitudeExtractor: _propTypes2.default.func.isRequired,
+  markerComponent: _propTypes2.default.func.isRequired,
+  propsForMarkers: _propTypes2.default.object,
+  fitBoundsOnLoad: _propTypes2.default.bool,
+  fitBoundsOnUpdate: _propTypes2.default.bool
 };
 exports.default = MarkerLayer;

--- a/lib/MarkerLayer.js
+++ b/lib/MarkerLayer.js
@@ -172,8 +172,8 @@ var MarkerLayer = function (_MapLayer) {
     return _react2.default.createElement(
       'div',
       { ref: function ref(c) {
-          return _this3.container = c;
-        },
+        return _this3.container = c;
+      },
         className: 'leaflet-objects-pane\n           leaflet-marker-pane\n           leaflet-zoom-hide\n           react-leaflet-marker-layer' },
       this.renderMarkers()
     );
@@ -217,3 +217,6 @@ MarkerLayer.propTypes = {
   fitBoundsOnUpdate: _propTypes2.default.bool
 };
 exports.default = MarkerLayer;
+
+
+MarkerLayer.prototype.createLeafletElement = function () {};

--- a/src/MarkerLayer.js
+++ b/src/MarkerLayer.js
@@ -59,6 +59,8 @@ export default class MarkerLayer extends MapLayer {
     fitBoundsOnUpdate: PropTypes.bool,
   };
 
+  createLeafletElement = () => {};
+
   map: Object = null;
   markers: Object = {};
   container = null;
@@ -189,3 +191,5 @@ export default class MarkerLayer extends MapLayer {
   }
 
 }
+
+MarkerLayer.prototype.createLeafletElement = () => {};


### PR DESCRIPTION
Remove legacy ref style and make compatible with React v16

Note: Now throws error when ref is not implemented by custom marker component. Could also be just a warning, but error is better IMO